### PR TITLE
Stability Updates to Serial Mode through StatusUpdater

### DIFF
--- a/balsam/client/requests_client.py
+++ b/balsam/client/requests_client.py
@@ -8,9 +8,6 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import requests
 
-import warnings
-warnings.filterwarnings("ignore")
-
 from . import urls
 from .rest_base_client import RESTClient
 

--- a/balsam/client/requests_client.py
+++ b/balsam/client/requests_client.py
@@ -8,6 +8,9 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import requests
 
+import warnings
+warnings.filterwarnings("ignore")
+
 from . import urls
 from .rest_base_client import RESTClient
 
@@ -39,7 +42,7 @@ class RequestsClient(RESTClient):
         return cls(api_root=base_url)
 
     def __init__(
-        self, api_root: str, connect_timeout: float = 3.1, read_timeout: float = 120.0, retry_count: int = 3
+        self, api_root: str, connect_timeout: float = 30.1, read_timeout: float = 120.0, retry_count: int = 10
     ) -> None:
         self.api_root = api_root
         self.connect_timeout = connect_timeout
@@ -100,7 +103,7 @@ class RequestsClient(RESTClient):
                 logger.warning(f"Attempt Retry of Timed-out request {http_method} {absolute_url}")
                 self.backoff(exc)
             except requests.ConnectionError as exc:
-                logger.warning(f"Attempt retry of connection: {exc}")
+                logger.warning(f"Attempt retry ({self._attempt} of {self.retry_count}) of connection: {exc}")
                 self.backoff(exc)
             else:
                 try:

--- a/balsam/cmdline/job.py
+++ b/balsam/cmdline/job.py
@@ -298,7 +298,8 @@ def ls(
 @job.command()
 @click.option("-i", "--id", "job_ids", multiple=True, type=int)
 @click.option("-t", "--tag", "tags", multiple=True, type=str, callback=validate_tags)
-def rm(job_ids: List[int], tags: List[str]) -> None:
+@click.option("--all", is_flag=True, default=False)
+def rm(job_ids: List[int], tags: List[str], all: bool) -> None:
     """
     Remove Jobs
 
@@ -309,6 +310,10 @@ def rm(job_ids: List[int], tags: List[str]) -> None:
     2) Remove Jobs by Tags
 
         balsam job rm --tag workflow=temp-test
+
+    3) Remove all jobs (DANGER!)
+
+        balsam job rm --all
     """
     client: RESTClient = load_client()
     jobs = client.Job.objects.all()
@@ -316,6 +321,9 @@ def rm(job_ids: List[int], tags: List[str]) -> None:
         jobs = jobs.filter(id=job_ids)
     elif tags:
         jobs = jobs.filter(tags=tags)
+    elif all:
+        click.echo("THIS WILL DELETE ALL JOBS! CAUTION!")
+        pass
     else:
         raise click.BadParameter("Provide either list of Job ids or tags to delete")
     count = jobs.count()

--- a/balsam/cmdline/job.py
+++ b/balsam/cmdline/job.py
@@ -292,7 +292,7 @@ def ls(
                 state_dict = {"State": state.value, "Count": state_count}
                 state_data.append(state_dict)
 
-        table_print(data)
+        table_print(state_data)
 
 
 @job.command()

--- a/balsam/config/defaults/alcf_cooley/job-template.sh
+++ b/balsam/config/defaults/alcf_cooley/job-template.sh
@@ -16,7 +16,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/alcf_theta/job-template.sh
+++ b/balsam/config/defaults/alcf_theta/job-template.sh
@@ -25,7 +25,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/alcf_thetagpu/job-template.sh
+++ b/balsam/config/defaults/alcf_thetagpu/job-template.sh
@@ -49,7 +49,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/nersc_corihaswell/job-template.sh
+++ b/balsam/config/defaults/nersc_corihaswell/job-template.sh
@@ -12,7 +12,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/nersc_coriknl/job-template.sh
+++ b/balsam/config/defaults/nersc_coriknl/job-template.sh
@@ -11,7 +11,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/olcf_summit/job-template.sh
+++ b/balsam/config/defaults/olcf_summit/job-template.sh
@@ -15,7 +15,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min-2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/config/defaults/osx/job-template.sh
+++ b/balsam/config/defaults/osx/job-template.sh
@@ -9,7 +9,7 @@ echo "num_nodes: {{num_nodes}}"
 echo "wall_time_min: {{wall_time_min}}"
 echo "job_mode: {{job_mode}}"
 
-echo "filter_tags:" 
+echo "filter_tags:"
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %}
 
 {% if optional_params.get("shout") == "yes" %}
@@ -22,7 +22,7 @@ export BALSAM_SITE_PATH={{balsam_site_path}}
 cd $BALSAM_SITE_PATH
 
 echo "Starting balsam launcher at $(date)"
-{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min}}  \
+{{launcher_cmd}} -j {{job_mode}} -t {{wall_time_min - 2}}  \
 {% for k, v in filter_tags.items() %} --tag {{k}}={{v}} {% endfor %} \
 {{partitions}}
 echo "Balsam launcher done at $(date)"

--- a/balsam/site/launcher/_serial_mode_master.py
+++ b/balsam/site/launcher/_serial_mode_master.py
@@ -78,6 +78,11 @@ class Master:
         msg = self.socket.recv_json()
         now = datetime.utcnow()
         finished_ids = set()
+
+        if not self.status_updater.is_alive():
+            logger.error("StatusUpdater is DOWN.  Aborting job!")
+            self.sig_handler.set()
+
         for id in msg["done"]:
             self.status_updater.put(
                 id,


### PR DESCRIPTION
On Theta in particular, the stability of outgoing connections is poor.  This causes jobs to quietly fail when the StatusUpdater goes down, preventing information flow back to the balsam server.

This pull request recommends an increase in the default retry count (to 10) which is set in ~/.balsam/client.yml.  That change isn't included here.

Additionally, this pull request adds timeout padding to all job templates, to allow balsam to gracefully shutdown.  Abrupt shutdowns appear to still be an issue.

Finally, there is an addition in the serial mode job master to continuously check if the StatusUpdater is still alive.  If that thread has died, likely due to connection issues, the entire job will terminate because no work after the updater goes down will be communicated back to the server, and is therefore very difficult to recover.