### PR TITLE
Speed up queries with job/app index and increase in paging size

### DIFF
--- a/balsam/schemas/__init__.py
+++ b/balsam/schemas/__init__.py
@@ -49,7 +49,7 @@ from .transfer import (
 )
 from .user import UserCreate, UserOut
 
-MAX_PAGE_SIZE = 10_000
+MAX_PAGE_SIZE = 100_000
 MAX_ITEMS_PER_BULK_OP = 5000
 
 __all__ = [

--- a/balsam/server/models/alembic/versions/f0ef7fd915a1_add_indexes_to_speed_up_job_queries.py
+++ b/balsam/server/models/alembic/versions/f0ef7fd915a1_add_indexes_to_speed_up_job_queries.py
@@ -1,0 +1,25 @@
+"""add indexes to speed up job queries
+
+Revision ID: f0ef7fd915a1
+Revises: 8c75d069a1ab
+Create Date: 2022-12-12 16:37:07.418906
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "f0ef7fd915a1"
+down_revision = "8c75d069a1ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # create index jobs_app_id_fkey on jobs (app_id);
+    op.create_index("jobs_app_id_fkey", "jobs", [text("app_id")])
+
+
+def downgrade():
+    op.drop_index("jobs_app_id_fkey")


### PR DESCRIPTION
The increase in paging size from 10K to 100K produces a significant speedup in job queries; in some cases, the speedup is from 30000ms to 2ms. This is in part due to a change in the query plan chosen by the DB server in these cases, and in part due to the new index.

This report was useful: https://dba.stackexchange.com/questions/213262/why-is-this-query-with-where-order-by-and-limit-so-slow