### PR TITLE
Update PyZMQ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     env:
       PYTHON: ${{ matrix.python-version }}
       OS: ubuntu

--- a/balsam/site/launcher/_serial_mode_master.py
+++ b/balsam/site/launcher/_serial_mode_master.py
@@ -117,9 +117,9 @@ class Master:
     def handle_request(self) -> None:
         msg = self.socket.recv_json()
 
-        done_ids: List[int] = msg["done"]
-        error_logs: List[Tuple[int, int, str]] = msg["error"]
-        started_ids: List[int] = msg["started"]
+        done_ids: List[int] = msg["done"]  # type: ignore
+        error_logs: List[Tuple[int, int, str]] = msg["error"]  # type: ignore
+        started_ids: List[int] = msg["started"]  # type: ignore
         self.update_job_states(done_ids, error_logs, started_ids)
 
         finished_ids = set(done_ids) | set(log[0] for log in error_logs)
@@ -127,8 +127,8 @@ class Master:
         self.active_ids -= finished_ids
         self.num_outstanding_jobs -= len(finished_ids)
 
-        src = msg["source"]
-        max_jobs: int = msg["request_num_jobs"]
+        src = msg["source"]  # type: ignore
+        max_jobs: int = msg["request_num_jobs"]  # type: ignore
         logger.debug(f"Worker {src} requested {max_jobs} jobs")
         new_job_specs = self.acquire_jobs(max_jobs)
 
@@ -154,9 +154,9 @@ class Master:
     def run(self) -> None:
         logger.debug("In master run")
         try:
-            self.context = zmq.Context()  # type: ignore
-            self.context.setsockopt(zmq.LINGER, 0)  # type: ignore
-            self.socket = self.context.socket(zmq.REP)  # type: ignore
+            self.context = zmq.Context()
+            self.context.setsockopt(zmq.LINGER, 0)
+            self.socket = self.context.socket(zmq.REP)
             self.socket.bind(f"tcp://*:{self.master_port}")
             logger.debug("Master ZMQ socket bound.")
 
@@ -173,7 +173,7 @@ class Master:
             self.shutdown()
             self.socket.setsockopt(zmq.LINGER, 0)
             self.socket.close(linger=0)
-            self.context.term()  # type: ignore
+            self.context.term()
             logger.info("shutdown done: ensemble master exit gracefully")
 
     def shutdown(self) -> None:

--- a/balsam/site/launcher/_serial_mode_worker.py
+++ b/balsam/site/launcher/_serial_mode_worker.py
@@ -150,7 +150,7 @@ class Worker:
             self.cleanup_proc(id, timeout=self.CHECK_PERIOD)
         self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.close(linger=0)
-        self.context.term()  # type: ignore
+        self.context.term()
 
     def start_jobs(self) -> List[int]:
         started_ids = []
@@ -193,12 +193,12 @@ class Worker:
         response_msg = self.socket.recv_json()
         logger.debug("Worker response received")
 
-        if response_msg.get("exit"):
+        if response_msg.get("exit"):  # type: ignore
             logger.info(f"Worker {self.hostname} received exit message: break")
             return False
 
-        if response_msg.get("new_jobs"):
-            self.runnable_cache.update({job["id"]: job for job in response_msg["new_jobs"]})
+        if response_msg.get("new_jobs"):  # type: ignore
+            self.runnable_cache.update({job["id"]: job for job in response_msg["new_jobs"]})  # type: ignore
 
         logger.debug(
             f"{self.hostname} fraction available: {self.node_manager.aggregate_free_nodes()} "
@@ -208,9 +208,9 @@ class Worker:
         return True
 
     def run(self) -> None:
-        self.context = zmq.Context()  # type: ignore
-        self.context.setsockopt(zmq.LINGER, 0)  # type: ignore
-        self.socket = self.context.socket(zmq.REQ)  # type: ignore
+        self.context = zmq.Context()
+        self.context.setsockopt(zmq.LINGER, 0)
+        self.socket = self.context.socket(zmq.REQ)
         self.socket.connect(self.master_address)
         logger.debug(f"Worker connected to {self.master_address}")
 

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -26,7 +26,7 @@ requests==2.28.1
 psutil==5.9.2
 globus-sdk==3.14.0
 configobj==5.0.6
-pyzmq==22.3.0
+pyzmq==24.0.1
 dill==0.3.5.1
 tblib==1.7.0
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     psutil>=5.8.0,<6.0.0
     globus-sdk>=3.0.1,<4.0.0
     configobj>=5.0.6,<6.0.0
-    pyzmq>=22.1.0,<23.0.0
+    pyzmq>=24.0.1
     dill>=0.3.4,<1.0.0
     tblib>=1.7.0,<2.0.0
 


### PR DESCRIPTION
Current version of PyZMQ (22.3.0) doesn't work with Juypter. This PR:

* updates PyZMQ to 24.0.1 and requires an exact match to this version to avoid similar problems with other dependencies.
* Fixes static type checks with the new version.
* Adds Python 3.10 to the CI.