### PR TITLE
Staged pbs qstat

### DIFF
--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -146,6 +146,10 @@ class PBSScheduler(SubprocessSchedulerInterface):
         return args
 
     @staticmethod
+    def _render_status_args(project: Optional[str], user: Optional[str], queue: Optional[str]) -> List[str]:
+        pass
+
+    @staticmethod
     def _render_delete_args(job_id: Union[int, str]) -> List[str]:
         return [PBSScheduler.delete_exe, str(job_id)]
 

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -166,7 +166,7 @@ class PBSScheduler(SubprocessSchedulerInterface):
             logger.warning(f"Exception: {exc}")
             raise
     
-    @staticmethod
+    @classmethod
     def get_statuses(
         cls,
         project: Optional[str] = None,
@@ -176,9 +176,8 @@ class PBSScheduler(SubprocessSchedulerInterface):
         
         # First call qstat to get user job ids
         args = [PBSScheduler.status_exe]
-        args += ["-u", user, queue]
         stdout = scheduler_subproc(args).split("\n")
-        stdout = [s for s in stdout if user in s if queue in s]
+        stdout = [s for s in stdout if user in s]
         if len(stdout) == 0:
             return [] #if there are no jobs in the queue return an empty list
         user_job_ids = [s.split('.')[0] for s in stdout]

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -173,7 +173,6 @@ class PBSScheduler(SubprocessSchedulerInterface):
         user: Optional[str] = getpass.getuser(),
         queue: Optional[str] = None,
     ) -> Dict[int, SchedulerJobStatus]:
-
         # First call qstat to get user job ids
         args = [PBSScheduler.status_exe]
         if queue is not None:
@@ -182,7 +181,7 @@ class PBSScheduler(SubprocessSchedulerInterface):
         stdout = [s for s in stdout if user in s]
         if len(stdout) == 0:
             return {}  # if there are no jobs in the queue return an empty dictionary
-        user_job_ids = [s.split('.')[0] for s in stdout]
+        user_job_ids = [s.split(".")[0] for s in stdout]
 
         # Next call qstat to get job jsons
         args = [PBSScheduler.status_exe]

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -175,8 +175,6 @@ class PBSScheduler(SubprocessSchedulerInterface):
     ) -> Dict[int, SchedulerJobStatus]:
         # First call qstat to get user job ids
         args = [PBSScheduler.status_exe]
-        if queue is not None:
-            args += [queue]
         stdout = scheduler_subproc(args).split("\n")
         stdout = [s for s in stdout if user in s]
         if len(stdout) == 0:

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -175,11 +175,11 @@ class PBSScheduler(SubprocessSchedulerInterface):
     ) -> Dict[int, SchedulerJobStatus]:
         # First call qstat to get user job ids
         args = [PBSScheduler.status_exe]
-        stdout = scheduler_subproc(args).split("\n")
-        stdout = [s for s in stdout if user in s]
-        if len(stdout) == 0:
+        stdout = scheduler_subproc(args)
+        stdout_lines = [s for s in stdout.split("\n") if str(user) in s]
+        if len(stdout_lines) == 0:
             return {}  # if there are no jobs in the queue return an empty dictionary
-        user_job_ids = [s.split(".")[0] for s in stdout]
+        user_job_ids = [s.split(".")[0] for s in stdout_lines]
 
         # Next call qstat to get job jsons
         args = [PBSScheduler.status_exe]

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -165,7 +165,7 @@ class PBSScheduler(SubprocessSchedulerInterface):
             # Catch errors here and handle
             logger.warning(f"Exception: {exc}")
             raise
-    
+
     @classmethod
     def get_statuses(
         cls,
@@ -173,13 +173,15 @@ class PBSScheduler(SubprocessSchedulerInterface):
         user: Optional[str] = getpass.getuser(),
         queue: Optional[str] = None,
     ) -> Dict[int, SchedulerJobStatus]:
-        
+
         # First call qstat to get user job ids
         args = [PBSScheduler.status_exe]
+        if queue is not None:
+            args += [queue]
         stdout = scheduler_subproc(args).split("\n")
         stdout = [s for s in stdout if user in s]
         if len(stdout) == 0:
-            return {} #if there are no jobs in the queue return an empty dictionary
+            return {}  # if there are no jobs in the queue return an empty dictionary
         user_job_ids = [s.split('.')[0] for s in stdout]
 
         # Next call qstat to get job jsons

--- a/balsam/platform/scheduler/pbs_sched.py
+++ b/balsam/platform/scheduler/pbs_sched.py
@@ -179,7 +179,7 @@ class PBSScheduler(SubprocessSchedulerInterface):
         stdout = scheduler_subproc(args).split("\n")
         stdout = [s for s in stdout if user in s]
         if len(stdout) == 0:
-            return [] #if there are no jobs in the queue return an empty list
+            return {} #if there are no jobs in the queue return an empty dictionary
         user_job_ids = [s.split('.')[0] for s in stdout]
 
         # Next call qstat to get job jsons


### PR DESCRIPTION
This changes the way pbs_sched gets info from the queue on the user's jobs.  First qstat is executed and all the batch job ids for the user's jobs are fetched.  Then qstat -f -F json is executed on just the jobs that belong to the user.  It's unclear if this will fix #324 but it will decrease the amount of data in JSON format parsed by _parse_logs.