### PR TITLE
Updates to app run for Perlmutter

### DIFF
--- a/balsam/platform/app_run/perlmutter.py
+++ b/balsam/platform/app_run/perlmutter.py
@@ -8,6 +8,11 @@ class PerlmutterRun(SubprocessAppRun):
     https://slurm.schedmd.com/srun.html
     """
 
+    def _get_cpus_per_task(self) -> int:
+        cpu_per_rank = 64 // self._ranks_per_node
+        cpu_per_task = cpu_per_rank*2
+        return cpu_per_task
+
     def _build_cmdline(self) -> str:
         node_ids = [h for h in self._node_spec.hostnames]
         num_nodes = str(len(node_ids))
@@ -22,6 +27,11 @@ class PerlmutterRun(SubprocessAppRun):
         else:
             gpu_args = []
 
+        launch_params = []
+        for k in self._launch_params.keys():
+            launch_params.append(k)
+            launch_params.append(str(self._launch_params[k]))
+            
         args = [
             "srun",
             *network_args,
@@ -35,8 +45,8 @@ class PerlmutterRun(SubprocessAppRun):
             "--nodes",
             num_nodes,
             "--cpus-per-task",
-            self.get_cpus_per_rank(),
-            "--mem=40G",
+            self._get_cpus_per_task(),
+            *launch_params,
             "--overlap",
             self._cmdline,
         ]

--- a/balsam/platform/app_run/perlmutter.py
+++ b/balsam/platform/app_run/perlmutter.py
@@ -24,7 +24,7 @@ class PerlmutterRun(SubprocessAppRun):
 
         launch_params = []
         for k in self._launch_params.keys():
-            launch_params.append("--"+k)
+            launch_params.append("--" + k)
             launch_params.append(str(self._launch_params[k]))
 
         args = [

--- a/balsam/platform/app_run/perlmutter.py
+++ b/balsam/platform/app_run/perlmutter.py
@@ -8,11 +8,6 @@ class PerlmutterRun(SubprocessAppRun):
     https://slurm.schedmd.com/srun.html
     """
 
-    def _get_cpus_per_task(self) -> int:
-        cpu_per_rank = 64 // self._ranks_per_node
-        cpu_per_task = cpu_per_rank*2
-        return cpu_per_task
-
     def _build_cmdline(self) -> str:
         node_ids = [h for h in self._node_spec.hostnames]
         num_nodes = str(len(node_ids))
@@ -29,7 +24,7 @@ class PerlmutterRun(SubprocessAppRun):
 
         launch_params = []
         for k in self._launch_params.keys():
-            launch_params.append(k)
+            launch_params.append("--"+k)
             launch_params.append(str(self._launch_params[k]))
             
         args = [
@@ -45,7 +40,7 @@ class PerlmutterRun(SubprocessAppRun):
             "--nodes",
             num_nodes,
             "--cpus-per-task",
-            self._get_cpus_per_task(),
+            self._threads_per_rank,
             *launch_params,
             "--overlap",
             self._cmdline,

--- a/balsam/platform/app_run/perlmutter.py
+++ b/balsam/platform/app_run/perlmutter.py
@@ -26,7 +26,7 @@ class PerlmutterRun(SubprocessAppRun):
         for k in self._launch_params.keys():
             launch_params.append("--"+k)
             launch_params.append(str(self._launch_params[k]))
-            
+
         args = [
             "srun",
             *network_args,


### PR DESCRIPTION
- I added an option to pass options to the command line through launch_params
- cpus-per-task is _virtual_ cpus per task, i.e. threads on Perlmutter
- mem=40G seemed oddly specific, unclear why this was introduced.  This can now be passed through launch_params if needed.