### PR TITLE
Reduce filter chunk size

### DIFF
--- a/balsam/_api/manager.py
+++ b/balsam/_api/manager.py
@@ -10,7 +10,7 @@ from .query import Query
 if TYPE_CHECKING:
     from balsam.client import RESTClient
 
-FILTER_CHUNK_SIZE = 512
+FILTER_CHUNK_SIZE = 500
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BalsamModel)


### PR DESCRIPTION
Reduce filter chunk size to reduce the length of URL querying server for events.  Fix to PR #246