### PR TITLE
split node names for machines that use full node address

### DIFF
--- a/balsam/_api/model.py
+++ b/balsam/_api/model.py
@@ -186,7 +186,7 @@ class BalsamModel(metaclass=BalsamModelMeta):
 
     def __str__(self) -> str:
         d = self.display_dict()
-        return yaml.dump(d, sort_keys=False, indent=4)  # type: ignore
+        return yaml.dump(d, sort_keys=False, indent=4)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BalsamModel):

--- a/balsam/config/config.py
+++ b/balsam/config/config.py
@@ -235,13 +235,10 @@ class Settings(BaseSettings):
             fp.write(self.dump_yaml())
 
     def dump_yaml(self) -> str:
-        return cast(
-            str,
-            yaml.dump(
-                json.loads(self.json()),
-                sort_keys=False,
-                indent=4,
-            ),
+        return yaml.dump(
+            json.loads(self.json()),
+            sort_keys=False,
+            indent=4,
         )
 
     @classmethod

--- a/balsam/site/launcher/_serial_mode_worker.py
+++ b/balsam/site/launcher/_serial_mode_worker.py
@@ -239,7 +239,7 @@ def worker_main(
 
     SigHandler()
     site_config.enable_logging("serial_mode", filename=log_filename + f".{hostname}")
-    if hostname == master_host:
+    if hostname == master_host.split(".")[0]:
         logger.info(f"Launching master subprocess on {hostname}")
         master_proc = launch_master_subprocess()
     else:
@@ -247,7 +247,8 @@ def worker_main(
 
     launch_settings = site_config.settings.launcher
     node_cls = launch_settings.compute_node
-    nodes = [node for node in node_cls.get_job_nodelist() if node.hostname == hostname]
+    logger.debug(f"node.hostname={node_cls.get_job_nodelist()[0].hostname} and hostname={hostname}")
+    nodes = [node for node in node_cls.get_job_nodelist() if node.hostname.split(".")[0] == hostname]
     node_manager = NodeManager(nodes, allow_node_packing=True)
     worker = Worker(
         app_run=launch_settings.local_app_launcher,


### PR DESCRIPTION
This PR fixes serial mode on Polaris.  The nodelist that serial mode would compare the local hostname to included the full node address, unlike the local hostname.  We now split the node names and compare just the first part of the name to the local hostname.