### PR TITLE
Problems with docker compose and the latest python:3-slim version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.10-slim
 
 WORKDIR /balsam
 


### PR DESCRIPTION
We get all kind of errors, See:
 * https://github.com/argonne-lcf/balsam/issues/343

so pinned it on `FROM python:3.10-slim`