### PR TITLE
pin dockerfile image to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3-slim
+FROM python:3.10-slim
+
+# Note that python 3.11 triggers a gunicorn bug as of June 2023
 
 WORKDIR /balsam
 


### PR DESCRIPTION
Problem: Python 3.11 will trigger a bug with gunicorn
Solution: pin to Python 3.10

This will fix #343 